### PR TITLE
:bug: 修复gocq的fgit源

### DIFF
--- a/nb_cli_plugin_littlepaimon/commands/create.py
+++ b/nb_cli_plugin_littlepaimon/commands/create.py
@@ -62,7 +62,7 @@ async def create(
                 '要使用的go-cqhttp下载源?',
                 [
                     Choice('Github官方源(国外推荐)', 'github.com'),
-                    Choice('FastGit镜像源(国内推荐)', 'download.fgit.ml'),
+                    Choice('FastGit镜像源(国内推荐)', 'download.fgit.cf'),
                 ],
                 default_select=1,
             ).prompt_async(style=CLI_DEFAULT_STYLE)


### PR DESCRIPTION
fgit.ml的证书过期了，暂时更换为fgit.cf，还有个fgit.gq，但是我这貌似不行，或者得稍微改一下用ghproxy感觉更稳
测试链接：[.cf](https://download.fgit.cf/Mrs4s/go-cqhttp/releases/latest/download/go-cqhttp_windows_amd64.zip)